### PR TITLE
Add allowUnauthorizedTls email option to accept self-signed certificate.

### DIFF
--- a/plugins/email/index.js
+++ b/plugins/email/index.js
@@ -13,6 +13,9 @@ const smtpConfig = {
   auth: {
     user: config.plugins.email.username,
     pass: config.plugins.email.password,
+  },
+  tls: {
+      rejectUnauthorized: !config.plugins.email.allowUnauthorizedTls
   }
 };
 


### PR DESCRIPTION
I created a local SMTP server with a self-signed certificate. With this change, the connection can be successful.