### PR TITLE
flowSaver flow column now uses bigint

### DIFF
--- a/plugins/flowSaver/db/saveFlow.js
+++ b/plugins/flowSaver/db/saveFlow.js
@@ -13,7 +13,7 @@ const createTable = async() => {
   return knex.schema.createTableIfNotExists(tableName, function(table) {
     table.integer('id');
     table.integer('port');
-    table.integer('flow');
+    table.bigInteger('flow');
     table.bigInteger('time');
     table.index(['time', 'port'], 'index');
   });

--- a/plugins/flowSaver/db/saveFlow5min.js
+++ b/plugins/flowSaver/db/saveFlow5min.js
@@ -13,7 +13,7 @@ const createTable = async() => {
   return knex.schema.createTableIfNotExists(tableName, function(table) {
     table.integer('id');
     table.integer('port');
-    table.integer('flow');
+    table.bigInteger('flow');
     table.bigInteger('time');
     table.index(['time', 'port'], 'index');
   });

--- a/plugins/flowSaver/db/saveFlowDay.js
+++ b/plugins/flowSaver/db/saveFlowDay.js
@@ -13,7 +13,7 @@ const createTable = async() => {
   return knex.schema.createTableIfNotExists(tableName, function(table) {
     table.integer('id');
     table.integer('port');
-    table.integer('flow');
+    table.bigInteger('flow');
     table.bigInteger('time');
     table.index(['time', 'port'], 'index');
   });

--- a/plugins/flowSaver/db/saveFlowHour.js
+++ b/plugins/flowSaver/db/saveFlowHour.js
@@ -13,7 +13,7 @@ const createTable = async() => {
   return knex.schema.createTableIfNotExists(tableName, function(table) {
     table.integer('id');
     table.integer('port');
-    table.integer('flow');
+    table.bigInteger('flow');
     table.bigInteger('time');
     table.index(['time', 'port'], 'index');
   });


### PR DESCRIPTION
The default column type for MySQL at least is INT which can only hold just over 2GB of data per entry which doesn't seem like it is enough.

Using BigINT should easily solve this issue.