### PR TITLE
allow use assign the email.port and email.secure

### DIFF
--- a/plugins/email/index.js
+++ b/plugins/email/index.js
@@ -16,8 +16,8 @@ if(!config.plugins.email.type) {
 if(config.plugins.email.type === 'smtp') {
   emailConfig = {
     host: config.plugins.email.host,
-    port: config.plugins.email.port || 465,
-    secure: (config.plugins.email.port === 465 || !config.plugins.email.port) ? true : false,
+    port: config.plugins.email.port,
+    secure: config.plugins.email.secure,
     auth: {
       user: config.plugins.email.username,
       pass: config.plugins.email.password,


### PR DESCRIPTION
遇到这么一个场景。

我使用 DigitalOcean 部署 shadowsocks，但是发邮件时总是出这个错 connect smtp timeout，因为 DigitalOcean 上 465 和 25 端口是 block 的

所以，同时依据 nodemailer 的配置，我的 163 smtp 是这么配置的：

```
port: 994
secure: true
```

这样在 DigitalOcean 上才能通过 163 成功发送邮件。

![screen shot 2018-06-02 at 11 15 26 am](https://user-images.githubusercontent.com/8650793/40869908-5859cbcc-6656-11e8-80e9-bec1c77d79f9.png)



