### PR TITLE
修复当密码为纯数字的时候bug

### DIFF
--- a/plugins/webgui/server/adminAccount.js
+++ b/plugins/webgui/server/adminAccount.js
@@ -261,7 +261,7 @@ exports.getSubscribeAccountForUser = async (req, res) => {
         return {
           cipher: server.method,
           name: server.subscribeName || server.name,
-          password: subscribeAccount.account.password,
+          password: String(subscribeAccount.account.password),
           port: subscribeAccount.account.port + server.shift,
           server: server.host,
           type: 'ss'


### PR DESCRIPTION
订阅返回的数据如下图：
![image](https://user-images.githubusercontent.com/8606484/54265090-7b325400-45af-11e9-8e32-e001ebf34ff4.png)

clash会把密码纯数字的识别为float类型，导致出错，错误提示如下：
![image](https://user-images.githubusercontent.com/8606484/54265164-a6b53e80-45af-11e9-8394-c2b5391cb9ca.png)
