### PR TITLE
Fix Chrome cannot login

### DIFF
--- a/plugins/webgui/index.js
+++ b/plugins/webgui/index.js
@@ -16,7 +16,7 @@ const sessionParser = session({
   rolling: true,
   resave: true,
   saveUninitialized: true,
-  cookie: { secure: false, httpOnly: true, maxAge: 7 * 24 * 3600 * 1000, sameSite: 'none', },
+  cookie: { secure: false, httpOnly: true, maxAge: 7 * 24 * 3600 * 1000, samesite: "lax" },
   store,
 });
 const bodyParser = require('body-parser');


### PR DESCRIPTION
Chrome rejects cookies with SameSite="none" and Secure="false" since version 80.