### PR TITLE
feat: add shadowsocks plugin support

### DIFF
--- a/plugins/flowSaver/db/server.js
+++ b/plugins/flowSaver/db/server.js
@@ -14,6 +14,13 @@ const createTable = async () => {
         table.integer('tjPort');
       });
     }
+
+    const hasPluginOptions = await knex.schema.hasColumn(tableName, 'pluginOptions');
+    if(!hasPluginOptions) {
+      await knex.schema.table(tableName, function(table) {
+        table.string('pluginOptions');
+      });
+    }
   } else {
     await knex.schema.createTable(tableName, function(table) {
       table.increments('id');
@@ -30,6 +37,7 @@ const createTable = async () => {
       table.string('net');
       table.integer('wgPort');
       table.integer('tjPort');
+      table.string('pluginOptions');
     });
   }
   const list = await knex('server').select(['name', 'host', 'port', 'password']);

--- a/plugins/flowSaver/server.js
+++ b/plugins/flowSaver/server.js
@@ -17,6 +17,7 @@ const add = async options => {
     net,
     wgPort,
     tjPort,
+    pluginOptions,
   } = options;
   const [ serverId ] = await knex('server').insert({
     type,
@@ -32,6 +33,7 @@ const add = async options => {
     net,
     wgPort,
     tjPort,
+    pluginOptions,
   });
   accountFlow.addServer(serverId);
   return [ serverId ];
@@ -51,7 +53,7 @@ const edit = async options => {
     id,
     type = 'Shadowsocks',
     name, host, port, password, method, scale = 1, comment = '', shift = 0,
-    key, net, wgPort, tjPort,
+    key, net, wgPort, tjPort, pluginOptions,
     check,
   } = options;
   const serverInfo = await knex('server').where({ id }).then(s => s[0]);
@@ -85,6 +87,7 @@ const edit = async options => {
     net,
     wgPort,
     tjPort,
+    pluginOptions,
   });
 };
 
@@ -104,6 +107,7 @@ const list = async (options = {}) => {
     'net',
     'wgPort',
     'tjPort',
+    'pluginOptions',
   ]).orderBy('name');
   if(options.status) {
     const serverStatus = [];

--- a/plugins/webgui/public/controllers/adminServer.js
+++ b/plugins/webgui/public/controllers/adminServer.js
@@ -507,6 +507,7 @@ app.controller('AdminServerController', ['$scope', '$http', '$state', 'moment', 
       net: $stateParams.net,
       wgPort: $stateParams.wgPort,
       tjPort: $stateParams.tjPort,
+      pluginOptions: $stateParams.pluginOptions,
     };
     $scope.tags = ($stateParams.tags || []);
     $scope.tagsAutoComplete = {
@@ -541,6 +542,7 @@ app.controller('AdminServerController', ['$scope', '$http', '$state', 'moment', 
         net: $scope.server.net,
         wgPort: $scope.server.wgPort ? +$scope.server.wgPort : null,
         tjPort: $scope.server.tjPort ? +$scope.server.tjPort : null,
+        pluginOptions: $scope.server.pluginOptions,
       }, {
         timeout: 15000,
       }).then(success => {
@@ -585,6 +587,7 @@ app.controller('AdminServerController', ['$scope', '$http', '$state', 'moment', 
         net: $scope.server.net,
         wgPort: $scope.server.wgPort,
         tjPort: $scope.server.tjPort,
+        pluginOptions: $scope.server.pluginOptions,
         tags: $scope.tags,
       });
     });
@@ -658,6 +661,7 @@ app.controller('AdminServerController', ['$scope', '$http', '$state', 'moment', 
       $scope.server.net = success.data.net;
       $scope.server.wgPort = success.data.wgPort;
       $scope.server.tjPort = success.data.tjPort;
+      $scope.server.pluginOptions = success.data.pluginOptions;
     });
     $scope.confirm = () => {
       alertDialog.loading();
@@ -681,6 +685,7 @@ app.controller('AdminServerController', ['$scope', '$http', '$state', 'moment', 
           net: $scope.server.net,
           wgPort: $scope.server.wgPort ? +$scope.server.wgPort : null,
           tjPort: $scope.server.tjPort ? +$scope.server.tjPort : null,
+          pluginOptions: $scope.server.pluginOptions,
           check: $scope.server.check,
         }),
       ]).then(() => {

--- a/plugins/webgui/public/translate/en-US.js
+++ b/plugins/webgui/public/translate/en-US.js
@@ -193,6 +193,8 @@ module.exports = {
   '密码': 'Password',
   '加密方式': 'Encryption Method',
   '流量倍率': 'Traffic Multiplier',
+  '端口偏移': 'Port Shift',
+  '插件参数': 'Plugin Parameters',
 
   '取消': 'Cancel',
   '删除': 'Delete',

--- a/plugins/webgui/public/views/admin/addServer.html
+++ b/plugins/webgui/public/views/admin/addServer.html
@@ -90,6 +90,10 @@
                         <div ng-message="required">端口偏移量不能为空</div>
                     </div>
                 </md-input-container>
+                <md-input-container class="md-block">
+                    <label translate>插件参数</label>
+                    <input type="text" name="pluginOptions" ng-model="server.pluginOptions">
+                </md-input-container>
                 <div style="width: 100%;">
                     <md-chips ng-model="tags" placeholder="请输入标签">
                         <md-autocomplete

--- a/plugins/webgui/public/views/admin/editServer.html
+++ b/plugins/webgui/public/views/admin/editServer.html
@@ -90,6 +90,10 @@
                         <div ng-message="required" translate>端口偏移量不能为空</div>
                     </div>
                 </md-input-container>
+                <md-input-container class="md-block">
+                    <label translate>插件参数</label>
+                    <input type="text" name="pluginOptions" ng-model="server.pluginOptions">
+                </md-input-container>
                 <div style="width: 100%;">
                     <md-chips ng-model="tags" placeholder="请输入标签">
                         <md-autocomplete

--- a/plugins/webgui/server/adminAccount.js
+++ b/plugins/webgui/server/adminAccount.js
@@ -268,7 +268,7 @@ exports.getSubscribeAccountForUser = async (req, res) => {
             return input;
           }
         };
-        insertFlow.subscribeName = `${toFlowString(currentFlow)}/${toFlowString(flow)}`;
+        insertFlow.subscribeName = `${toFlowString(currentFlow)} / ${toFlowString(flow)} (${(currentFlow*100/flow).toFixed(1)}%)`;
       }
       subscribeAccount.server = [
         ...(insertFlow.subscribeName ? [insertFlow] : []),
@@ -295,7 +295,8 @@ exports.getSubscribeAccountForUser = async (req, res) => {
             password: String(subscribeAccount.account.password),
             port: subscribeAccount.account.port + server.shift,
             server: server.host,
-            type: 'ss'
+            type: 'ss',
+            ...(server.pluginOptions ? JSON.parse(server.pluginOptions.replace(/\${port}/g, subscribeAccount.account.port+server.shift))['clash'] : {})
           })),
           ...trojanServers.map(server => ({
             name: server.subscribeName || server.name,

--- a/plugins/webgui/server/adminServer.js
+++ b/plugins/webgui/server/adminServer.js
@@ -69,6 +69,7 @@ exports.addServer = async (req, res) => {
     const net = isWG ? req.body.net: null;
     const wgPort = isWG ? req.body.wgPort : null;
     const tjPort = isTj ? req.body.tjPort : null;
+    const pluginOptions = req.body.pluginOptions;
     await manager.send({
       command: 'flow',
       options: { clear: false, },
@@ -91,6 +92,7 @@ exports.addServer = async (req, res) => {
       net,
       wgPort,
       tjPort,
+      pluginOptions,
     });
     res.send({ serverId });
   } catch(err) {
@@ -127,6 +129,7 @@ exports.editServer = async (req, res) => {
     const net = isWG ? req.body.net: null;
     const wgPort = isWG ? req.body.wgPort : null;
     const tjPort = isTj ? req.body.tjPort : null;
+    const pluginOptions = req.body.pluginOptions;
     const check = +req.body.check;
     await manager.send({
       command: 'flow',
@@ -151,6 +154,7 @@ exports.editServer = async (req, res) => {
       net,
       wgPort,
       tjPort,
+      pluginOptions,
       check,
     });
     res.send('success');

--- a/plugins/webgui/server/clash.js
+++ b/plugins/webgui/server/clash.js
@@ -2,9 +2,19 @@ module.exports = {
   proxies: [],
   "proxy-groups": [
     {
+      "name": "✈自动选优",
+      "type": "url-test",
+      "proxies": [
+        "placeholder",
+      ],
+      "url": "http://google.com/generate_204",
+      "interval": 3600
+    },
+    {
       "name": "🔰国外流量",
       "type": "select",
       "proxies": [
+        "✈自动选优",
         "placeholder",
         "🚀直接连接"
       ]
@@ -14,6 +24,7 @@ module.exports = {
       "type": "select",
       "proxies": [
         "🔰国外流量",
+        "✈自动选优",
         "🚀直接连接"
       ]
     },
@@ -22,6 +33,7 @@ module.exports = {
       "type": "select",
       "proxies": [
         "🔰国外流量",
+        "✈自动选优",
         "placeholder"
       ]
     },
@@ -30,6 +42,7 @@ module.exports = {
       "type": "select",
       "proxies": [
         "🔰国外流量",
+        "✈自动选优",
         "placeholder"
       ]
     },
@@ -38,6 +51,7 @@ module.exports = {
       "type": "select",
       "proxies": [
         "🔰国外流量",
+        "✈自动选优",
         "placeholder"
       ]
     },
@@ -46,6 +60,7 @@ module.exports = {
       "type": "select",
       "proxies": [
         "🔰国外流量",
+        "✈自动选优",
         "placeholder"
       ]
     },
@@ -54,6 +69,7 @@ module.exports = {
       "type": "select",
       "proxies": [
         "🚀直接连接",
+        "✈自动选优",
         "🔰国外流量"
       ]
     },


### PR DESCRIPTION
## add shadowsocks plugin support, one can config plugin via yaml and webgui.

1. To enable a shadowsocks plugin, at the 's' side

  ```yaml
  type: s
  
  shadowsocks:
    address: 127.0.0.1:1234
    # These 2 lines are newly added
    plugin: v2ray-plugin
    plugin-opts: "server;mode=websocket;path=/ws;mux=0;"
  manager:
    address: 0.0.0.0:2345
    password: 'your password'
  db: '/path/to/ss.sqlite'
  ```

2. (Optional Step) In webgui web page:

  I say it optional, because by doing step 1, you have already made the plugin enabled. By doing step 2, you can make subscription link work correct.

  ![image](https://user-images.githubusercontent.com/8508493/124772343-8672d000-df6e-11eb-8e12-238384da6c6a.png)

  You can edit plugin options here, the syntax is:

  ```json
  {
      "subscribeType1": {
          "yourConfigKey": "yourConfigValue",
      },
      "subscribeType2": {
          "yourConfigKey": "yourConfigValue",
      }
  }
  ```
  
  An complex example to use cdn websocket:
  
  ```json
  {
      "clash": {
          "server": "cdn.example.com",
          "port": 443,
          "udp": true,
          "plugin": "v2ray-plugin",
          "plugin-opts": {
	      "mode": "websocket",
	      "tls": true,
	      "host": "cdn.example.com",
	      "path": "/fw/${port}",
	      "mux": false
          }
      },
      "ssd": {
          "plugin": "/?plugin=v2ray-plugin;mode%3Dwebsocket;tls%3Dtrue;host%3Dcdn.example.com;path%3D/fw/${port};mux%3Dfalse"
      },
      "potatso": {
          "plugin": "/?plugin=v2ray-plugin;mode%3Dwebsocket;tls%3Dtrue;host%3Dcdn.example.com;path%3D/fw/${port};mux%3Dfalse"
      }
  }
  ```

## Problems remained

I fixed the subscription of clash only. I'm not familiar with those all rules. I'll finish the rest of work if @gyteng you agreed to merge this kind of modification or I'll keep clash being the only working subscrpition because I use clash only.