### PR TITLE
feat: add plugin support for freeAccount

### DIFF
--- a/plugins/freeAccount/index.js
+++ b/plugins/freeAccount/index.js
@@ -29,6 +29,7 @@ const address = config.plugins.freeAccount.address;
 const method = config.plugins.freeAccount.method;
 const analytics = config.plugins.freeAccount.analytics || '';
 const password = config.plugins.freeAccount.password || '';
+const plugin = config.plugins.freeAccount.plugin ? `/?plugin=${config.plugins.freeAccount.plugin};${(config.plugins.freeAccount['plugin-opts'] || '').split(';').map(i=>encodeURIComponent(i)).join(';')}#` : '';
 
 let currentPassword = '';
 let updateTime = Date.now();
@@ -173,7 +174,7 @@ const checkPort = async () => {
       await manager.send({ command: 'add', port: randomPort(), password: randomPassword() });
       await setKey('create', { time: Date.now() });
       await setKey('flow', { flow: 0 });
-      qrcode = 'ss://' + Buffer.from(`${ method }:${ currentPassword }@${ address }:${ currentPort }`).toString('base64');
+      qrcode = 'ss://' + Buffer.from(`${ method }:${ currentPassword }`).toString('base64') + `@${ address }:${ currentPort }${ plugin }`;
     }
   }
 };
@@ -214,7 +215,7 @@ if(config.plugins.freeAccount.ad) {
 
 app.get('/', (req, res) => {
   logger.info(`[${ req.ip }] /`);
-  qrcode = 'ss://' + Buffer.from(`${ method }:${ currentPassword }@${ address }:${ currentPort }`).toString('base64');
+  qrcode = 'ss://' + Buffer.from(`${ method }:${ currentPassword }`).toString('base64') + `@${ address }:${ currentPort }${ plugin }`;
   return res.render('index', {
     recaptcha: config.plugins.freeAccount.recaptcha ? config.plugins.freeAccount.recaptcha.site : '',
     analytics,

--- a/plugins/freeAccount/views/index.html
+++ b/plugins/freeAccount/views/index.html
@@ -58,6 +58,20 @@
     <div class="row">
       <div class="address col-md-12 col-lg-12"></div>
     </div>
+    <div class="row">
+      <div class="qrcode col-md-12 col-lg-12">
+        软件下载：
+        <a href="https://github.com/shadowsocks/ShadowsocksX-NG/releases">macOS</a>
+        |
+        <a href="https://github.com/shadowsocks/shadowsocks-windows/releases">Windows</a>
+        |
+        <a href="https://github.com/shadowsocks/shadowsocks-qt5/releases">Linux GUI</a>
+        |
+        <a href="https://github.com/shadowsocks/shadowsocks-libev/releases">Linux CLI</a>
+        |
+        <a href="https://github.com/shadowsocks/shadowsocks-android/releases">Android</a>
+      </div>
+    </div>
     <script>
       var i = 0;
       var getToken = function() {
@@ -77,7 +91,7 @@
           }, function(data) {
             window.ssqrcode = data.qrcode;
             window.ssscore = data.score;
-            var qr = qrcode(8, 'Q');
+            var qr = qrcode(8, 'M');
             qr.addData(window.ssqrcode);
             qr.make();
             document.getElementById('qrcode').innerHTML = qr.createImgTag(6);


### PR DESCRIPTION
add support for freeAccount.

Usage:

The config file of 's' server is as below, which is compatible with my previous commit.

```yaml
type: s

shadowsocks:
  address: 127.0.0.1:12532
  plugin: "obfs-server"
  plugin-opts: "obfs=tls;failover=example.com:80"
manager:
  address: 0.0.0.0:12533
  password: 'yourPassword'
```

The config file of 'm' server is as below:

```yaml
type: m

manager:
  address: 127.0.0.1:12533
  password: 'yourPassword'
plugins:
  freeAccount:
    use: true
    port: 12901-12999
    flow: 3G
    time: 8h
    address: 'your.host.or.your.ip'
    method: 'chacha20-ietf-poly1305'
    plugin: "obfs-local"
    plugin-opts: "obfs=tls;failover=example.com:80"
    listen: '0.0.0.0:12534'
```

I've tested on my server, you can check it again.

Besides, I changed the index.html also in which I downgrade the qrcode errorCorrectLevel for more capacity of characters. A line addded to indicate the softwares can parse the ss URL or scan the qrcode.