### PR TITLE
fix TypeError [ERR_UNKNOWN_ENCODING]: Unknown encoding: base64url

### DIFF
--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -1,6 +1,8 @@
-FROM node:12-alpine
-LABEL maintainer="Gyteng <igyteng@gmail.com>"
-COPY ./shadowsocks-libev /tmp/repo
+FROM node:14-alpine
+
+ENV SS_LIBEV_VERSION=3.3.5
+ENV SS_DIR=shadowsocks-libev-${SS_LIBEV_VERSION}
+
 RUN set -ex \
   && apk add --no-cache --virtual .build-deps \
       autoconf \
@@ -13,8 +15,12 @@ RUN set -ex \
       linux-headers \
       mbedtls-dev \
       pcre-dev \
-  && cd /tmp/repo \
-  && ./autogen.sh \
+      curl \
+      tar \
+  && cd /tmp \
+  && curl -SL -k https://github.com/shadowsocks/shadowsocks-libev/releases/download/v${SS_LIBEV_VERSION}/shadowsocks-libev-${SS_LIBEV_VERSION}.tar.gz | tar xz \
+  && cd $SS_DIR \
+  && autoreconf --install --force \
   && ./configure --prefix=/usr --disable-documentation \
   && make install \
   && apk del .build-deps \
@@ -23,9 +29,13 @@ RUN set -ex \
       $(scanelf --needed --nobanner /usr/bin/ss-* \
       | awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
       | sort -u) \
-  && rm -rf /tmp/repo
+  && rm -rf /tmp/* \
+  && rm -rf /var/cache/apk/*
+
+
 RUN apk --no-cache add tzdata iproute2 && \
     ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
-    echo "Asia/Shanghai" > /etc/timezone && \
+    echo "Europe/Moscow" > /etc/timezone && \
     npm i -g shadowsocks-manager --unsafe-perm
+
 CMD ["ssmgr"]


### PR DESCRIPTION
Setup:
- docker
- Mac M1

Node 12 return
```
 } reason:
    TypeError [ERR_UNKNOWN_ENCODING]:
      Unknown encoding: base64url
     at Uint8Array.toString (buffer.js:800:11)
     at Object.generateVAPIDKeys (/usr/local/lib/node_modules/shadowsocks-manager/node_modules/web-push/src/vapid-helper.js:63:32)
     at Object.<anonymous> (/usr/local/lib/node_modules/shadowsocks-manager/plugins/webgui/server/push.js:2:27)
     at Module._compile (internal/modules/cjs/loader.js:999:30)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
     at Module.load (internal/modules/cjs/loader.js:863:32)
     at Function.Module._load (internal/modules/cjs/loader.js:708:14)
     at Module.require (internal/modules/cjs/loader.js:887:19)
     at require (internal/modules/cjs/helpers.js:74:18)
     at global.appRequire (/usr/local/lib/node_modules/shadowsocks-manager/init/utils.js:4:33)
     at Object.<anonymous> (/usr/local/lib/node_modules/shadowsocks-manager/plugins/webgui/server/home.js:12:14)
     at Module._compile (internal/modules/cjs/loader.js:999:30)
     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
     at Module.load (internal/modules/cjs/loader.js:863:32)
     at Function.Module._load (internal/modules/cjs/loader.js:708:14)
     at Module.require (internal/modules/cjs/loader.js:887:19) {
   code: 'ERR_UNKNOWN_ENCODING'
 }
```

Node 14 solve this error
